### PR TITLE
Handle gzip compressed CSV files

### DIFF
--- a/beam_utils/sources.py
+++ b/beam_utils/sources.py
@@ -80,7 +80,7 @@ class CsvFileSource(beam.io.filebasedsource.FileBasedSource):
     headers = None
     self._file = self.open_file(file_name)
 
-    reader = csv.reader(self._file, delimiter=self.delimiter)
+    reader = csv.reader(_Fileobj2Iterator(self._file), delimiter=self.delimiter)
 
     for i, rec in enumerate(reader):
       if (self.header or self.dictionary_output) and i == 0:
@@ -92,3 +92,18 @@ class CsvFileSource(beam.io.filebasedsource.FileBasedSource):
       else:
         res = rec
       yield res
+
+
+class _Fileobj2Iterator(object):
+
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        line = self._obj.readline()
+        if line == None or line == '':
+            raise StopIteration
+        return line

--- a/beam_utils/sources_test.py
+++ b/beam_utils/sources_test.py
@@ -2,12 +2,46 @@
 
 import unittest
 
-from beam_utils.sources import JsonLinesFileSource
+from beam_utils.sources import JsonLinesFileSource, CsvFileSource
+from apache_beam.io.fileio import CompressionTypes
 
+import gzip
+import tempfile
 try:
   from StringIO import StringIO
 except ImportError:
   from io import StringIO
+
+class TestCsvFileSource(unittest.TestCase):
+
+    CSV_LINES_FILE = """header1,header2,header3
+value1,value2,value3
+"""
+
+
+    def test_gzipped_csv(self):
+        out = StringIO()
+        with tempfile.NamedTemporaryFile() as f:
+            with gzip.GzipFile(filename=f.name, mode='wb') as gz:
+                gz.write(self.CSV_LINES_FILE)
+
+            csv = CsvFileSource(
+                    f.name,
+                    compression_type=CompressionTypes.GZIP)
+
+            # first record as a dict
+            rec = csv.read_records(f.name, None).next()
+
+            # make a dict from the csv lines
+            lines = self.CSV_LINES_FILE.split('\n')
+            csv_tuples = zip(lines[0].split(','), lines[1].split(','))
+            csv_dict = {header: value for (header, value) in csv_tuples}
+
+            # assert both dicts are equal
+            for (header, value) in rec.iteritems():
+                self.assertEqual(value, csv_dict[header])
+
+
 
 
 class TestJsonLinesFileSource(unittest.TestCase):


### PR DESCRIPTION
Added test case and a wrapper class to make a file object appear as an `iterator` when passed to `csv.reader()`.